### PR TITLE
Fix commands array assignment

### DIFF
--- a/lib/save-definitions.coffee
+++ b/lib/save-definitions.coffee
@@ -64,8 +64,8 @@ module.exports = class SaveDefinitions
 					match = minimatch(atom.project.relativize(filePath), glob)
 					if match
 						tempDef = @_parseDefinitionObject obj, dir
-						def.commands.concat(tempDef.commands)
-						def.scripts.concat(tempDef.scripts)
+						def.commands = def.commands.concat(tempDef.commands)
+						def.scripts = def.scripts.concat(tempDef.scripts)
 		return def
 
 	getDefinitions: (filePath, projectPath) ->


### PR DESCRIPTION
Without this nothing runs since the commands and scripts arrays remain empty (concat returns the result).
