### PR TITLE
Allow globs for groups in configuration.

### DIFF
--- a/lib/save-definitions.coffee
+++ b/lib/save-definitions.coffee
@@ -59,7 +59,7 @@ module.exports = class SaveDefinitions
 		def = {commands: [], scripts: []}
 		dir = _path.dirname(filePath)
 		for group, o of @cson
-			if group is "*" or group is projectPath
+			if group is "*" or (!!projectPath and minimatch(projectPath, group))
 				for glob, obj of o
 					match = minimatch(atom.project.relativize(filePath), glob)
 					if match


### PR DESCRIPTION
I have many projects written in a language, all of them in the same folder. I would like to run language-specific tools on each of the projects' files, but not configure the editor for each project separately. For that I need to be allowed to write a glob as a configuration group instead of a path.
