### PR TITLE
Fixes race condition when displaying multiple notifications

### DIFF
--- a/lib/save-autorun.coffee
+++ b/lib/save-autorun.coffee
@@ -127,7 +127,8 @@ module.exports = class SaveAutorun
 		if def.commands.length > 0
 			startMessage = @notifyInfo 'executing ' + def.commands.length + ' command(s)'
 			for rawCommand in def.commands
-				command = @prepareCommand(rawCommand, filePath, projectPath)
+				tmpCommand = @prepareCommand(rawCommand, filePath, projectPath)
+				`const command = tmpCommand`
 				@shell command, projectPath, (error, stdout, stderr) =>
 					startMessage.dismiss()
 					if error


### PR DESCRIPTION
Fixes race condition when showing notifications of command that completed.

This is caused because `command` gets overwritten every command, and then when the commands resolve, they print the same `command` variable which contains the last value rather than the actual command that was just executed. That's because coffeescript refuses to implement `const` and `let`.
    
Fixes Issue #20