### PR TITLE
Add option to run save-commands sequentially. 

### DIFF
--- a/lib/save-autorun.coffee
+++ b/lib/save-autorun.coffee
@@ -127,7 +127,8 @@ module.exports = class SaveAutorun
 		if def.commands.length > 0
 			startMessage = @notifyInfo 'executing ' + def.commands.length + ' command(s)'
 			for rawCommand in def.commands
-				command = @prepareCommand(rawCommand, filePath, projectPath)
+				tmpCommand = @prepareCommand(rawCommand, filePath, projectPath)
+				`const command = tmpCommand`
 				@shell command, projectPath, (error, stdout, stderr) =>
 					startMessage.dismiss()
 					if error


### PR DESCRIPTION
This option can't be selected for some rules and excluded in others,
that's already trying to become a pseudo build system and way out of
scope. Fixes #22

Consequently Fixes #20, a race condition that overwrote the title
of a notification.